### PR TITLE
Refactored / enhanced retrieval of home-directory:

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -59,6 +59,14 @@
  * Website - currenty http://stlsoft.org/ is *VERY* out of date
  * Set-up donation
 
+ * [ ] **winstl/api/internal/get_home_directory_.h**;
+  * [x] add `WINSTL_API_INTERNAL_System_get_home_directory_a_()` / `WINSTL_API_INTERNAL_System_get_home_directory_w_()`;
+  * [x] tries first for `"USERPROFILE"` and then falls back to `"HOMEDRIVE"` and `"HOMEPATH"`;
+  * [x] implement `winstl_C_get_home_directory_a()` / `winstl_C_get_home_directory_w()` (**winstl/system/directory_functions.h**) in terms of `WINSTL_API_INTERNAL_System_get_home_directory_a_()` / `WINSTL_API_INTERNAL_System_get_home_directory_w_()`;
+  * [x] add **test.component.winstl.system.directory_functions**;
+  * [ ] implement **unixstl_C_get_home_directory_invoke_getenv_a_()** in terms of `WINSTL_API_INTERNAL_System_get_home_directory_a_()`;
+ * [ ] `platformstl::FILE_stream` implemented in terms of **stlsoft/api/internal/memfns.h**;
+
 
 ## STLSoft 1.12+ TODOs:
 

--- a/include/winstl/api/internal/get_home_directory_.h
+++ b/include/winstl/api/internal/get_home_directory_.h
@@ -1,0 +1,211 @@
+/* /////////////////////////////////////////////////////////////////////////
+ * File:    winstl/api/internal/get_home_directory_.h
+ *
+ * Purpose: Internal adaptations for obtaining home directory.
+ *
+ * Created: 27th April 2025
+ * Updated: 27th April 2025
+ *
+ * Home:    http://stlsoft.org/
+ *
+ * Copyright (c) 2025, Matthew Wilson and Synesis Information Systems
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * - Neither the name(s) of Matthew Wilson and Synesis Synesis Information
+ *   Systems nor the names of any contributors may be used to endorse or
+ *   promote products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ////////////////////////////////////////////////////////////////////// */
+
+/* WARNING: this file contains undocumented internal features that are
+ * subject to change at any time, so if you use them it is at your own risk.
+ */
+
+#ifndef WINSTL_API_INTERNAL_H_get_home_directory_
+#define WINSTL_API_INTERNAL_H_get_home_directory_
+
+/* /////////////////////////////////////////////////////////////////////////
+ * includes
+ */
+
+#ifndef WINSTL_INCL_WINSTL_H_WINSTL
+#include <winstl/winstl.h>
+#endif /* !WINSTL_INCL_WINSTL_H_WINSTL */
+
+#ifndef STLSOFT_INCL_H_STDDEF
+#define STLSOFT_INCL_H_STDDEF
+#include <stddef.h>
+#endif /* !STLSOFT_INCL_H_STDDEF */
+
+#ifndef STLSOFT_INCL_STLSOFT_API_external_h_memfns
+#include <stlsoft/api/external/memfns.h>
+#endif /* !STLSOFT_INCL_STLSOFT_API_external_h_memfns */
+
+
+/* /////////////////////////////////////////////////////////////////////////
+ * functions
+ */
+
+STLSOFT_INLINE
+int WINSTL_API_INTERNAL_System_get_home_directory_a_(
+    CHAR    buffer[]
+,   DWORD   cchBuffer
+)
+{
+    WINSTL_ASSERT(NULL != buffer || 0 == cchBuffer);
+
+    {
+        DWORD const dw_up = STLSOFT_NS_GLOBAL_(GetEnvironmentVariableA)("USERPROFILE", buffer, cchBuffer);
+
+        if (0 == dw_up)
+        {
+            DWORD const le_1 = STLSOFT_NS_GLOBAL_(GetLastError)();
+
+            if (ERROR_ENVVAR_NOT_FOUND == le_1)
+            {
+                /* now try for "HOMEDRIVE" and "HOMEPATH" */
+
+                CHAR        drive[WINSTL_CONST_MAX_PATH];
+                CHAR        directory[WINSTL_CONST_MAX_PATH];
+                DWORD const cchDrive        =   STLSOFT_NS_GLOBAL_(GetEnvironmentVariableA)("HOMEDRIVE", &drive[0], STLSOFT_NUM_ELEMENTS(drive));
+                DWORD const le_2            =   STLSOFT_NS_GLOBAL_(GetLastError)();
+                DWORD const cchDirectory    =   STLSOFT_NS_GLOBAL_(GetEnvironmentVariableA)("HOMEPATH", &directory[0], STLSOFT_NUM_ELEMENTS(directory));
+                DWORD const le_3            =   STLSOFT_NS_GLOBAL_(GetLastError)();
+
+                if (0 == cchDrive)
+                {
+                    STLSOFT_NS_GLOBAL_(SetLastError)(le_2);
+
+                    return 0;
+                }
+
+                if (0 == cchDirectory)
+                {
+                    STLSOFT_NS_GLOBAL_(SetLastError)(le_3);
+
+                    return 0;
+                }
+
+                if (cchBuffer <= cchDrive + cchDirectory)
+                {
+                    return cchDrive + cchDirectory + 1;
+                }
+                else
+                {
+                    STLSOFT_API_EXTERNAL_memfns_memcpy(&buffer[0] + 0, drive, sizeof(CHAR) * cchDrive);
+                    STLSOFT_API_EXTERNAL_memfns_memcpy(&buffer[0] + cchDrive, directory, sizeof(CHAR) * cchDirectory);
+
+                    return cchDrive + cchDirectory;
+                }
+            }
+            else
+            {
+                return 0;
+            }
+        }
+        else
+        {
+            return dw_up;
+        }
+    }
+}
+
+STLSOFT_INLINE
+int WINSTL_API_INTERNAL_System_get_home_directory_w_(
+    WCHAR   buffer[]
+,   DWORD   cchBuffer
+)
+{
+    WINSTL_ASSERT(NULL != buffer || 0 == cchBuffer);
+
+    {
+        DWORD const dw_up = STLSOFT_NS_GLOBAL_(GetEnvironmentVariableW)(L"USERPROFILE", buffer, cchBuffer);
+
+        if (0 == dw_up)
+        {
+            DWORD const le_1 = STLSOFT_NS_GLOBAL_(GetLastError)();
+
+            if (ERROR_ENVVAR_NOT_FOUND == le_1)
+            {
+                /* now try for "HOMEDRIVE" and "HOMEPATH" */
+
+                WCHAR       drive[WINSTL_CONST_MAX_PATH];
+                WCHAR       directory[WINSTL_CONST_MAX_PATH];
+                DWORD const cchDrive        =   STLSOFT_NS_GLOBAL_(GetEnvironmentVariableW)(L"HOMEDRIVE", &drive[0], STLSOFT_NUM_ELEMENTS(drive));
+                DWORD const le_2            =   STLSOFT_NS_GLOBAL_(GetLastError)();
+                DWORD const cchDirectory    =   STLSOFT_NS_GLOBAL_(GetEnvironmentVariableW)(L"HOMEPATH", &directory[0], STLSOFT_NUM_ELEMENTS(directory));
+                DWORD const le_3            =   STLSOFT_NS_GLOBAL_(GetLastError)();
+
+                if (0 == cchDrive)
+                {
+                    STLSOFT_NS_GLOBAL_(SetLastError)(le_2);
+
+                    return 0;
+                }
+
+                if (0 == cchDirectory)
+                {
+                    STLSOFT_NS_GLOBAL_(SetLastError)(le_3);
+
+                    return 0;
+                }
+
+                if (cchBuffer <= cchDrive + cchDirectory)
+                {
+                    return cchDrive + cchDirectory + 1;
+                }
+                else
+                {
+                    STLSOFT_API_EXTERNAL_memfns_memcpy(&buffer[0] + 0, drive, sizeof(WCHAR) * cchDrive);
+                    STLSOFT_API_EXTERNAL_memfns_memcpy(&buffer[0] + cchDrive, directory, sizeof(WCHAR) * cchDirectory);
+
+                    return cchDrive + cchDirectory;
+                }
+            }
+            else
+            {
+                return 0;
+            }
+        }
+        else
+        {
+            return dw_up;
+        }
+    }
+}
+
+
+/* /////////////////////////////////////////////////////////////////////////
+ * inclusion control
+ */
+
+#ifdef STLSOFT_CF_PRAGMA_ONCE_SUPPORT
+#pragma once
+#endif /* STLSOFT_CF_PRAGMA_ONCE_SUPPORT */
+
+#endif /* WINSTL_API_INTERNAL_H_get_home_directory_ */
+
+/* ///////////////////////////// end of file //////////////////////////// */
+

--- a/include/winstl/system/directory_functions.h
+++ b/include/winstl/system/directory_functions.h
@@ -4,11 +4,11 @@
  * Purpose: Directory functions.
  *
  * Created: 29th January 2013
- * Updated: 5th November 2024
+ * Updated: 27th April 2025
  *
  * Home:    http://stlsoft.org/
  *
- * Copyright (c) 2019-2024, Matthew Wilson and Synesis Information Systems
+ * Copyright (c) 2019-2025, Matthew Wilson and Synesis Information Systems
  * Copyright (c) 2013-2019, Matthew Wilson and Synesis Software
  * All rights reserved.
  *
@@ -69,6 +69,10 @@
 # pragma message(__FILE__)
 #endif /* STLSOFT_TRACE_INCLUDE */
 
+#ifndef WINSTL_API_INTERNAL_H_get_home_directory_
+# include <winstl/api/internal/get_home_directory_.h>
+#endif /* WINSTL_API_INTERNAL_H_get_home_directory_ */
+
 #ifndef WINSTL_INCL_WINSTL_API_external_h_SystemInformation
 # include <winstl/api/external/SystemInformation.h>
 #endif /* !WINSTL_INCL_WINSTL_API_external_h_SystemInformation */
@@ -109,35 +113,7 @@ winstl_C_get_home_directory_a(
 ,   ws_size_t   cchBuffer
 )
 {
-    /* NOTE: assumes that HOMEDRIVE and HOMEPATH can never be larger than _MAX_PATH */
-
-    ws_char_a_t     drive[WINSTL_CONST_MAX_PATH];
-    ws_char_a_t     directory[WINSTL_CONST_MAX_PATH];
-    DWORD const     cchDrive        =   WINSTL_API_EXTERNAL_SystemInformation_GetEnvironmentVariableA("HOMEDRIVE", &drive[0], STLSOFT_NUM_ELEMENTS(drive));
-    DWORD const     cchDirectory    =   (0 == cchDrive) ? 0 : WINSTL_API_EXTERNAL_SystemInformation_GetEnvironmentVariableA("HOMEPATH", &directory[0], STLSOFT_NUM_ELEMENTS(directory));
-    DWORD const     cchTotal        =   cchDrive + cchDirectory;
-
-    if (0 == cchDirectory)
-    {
-        return 0;
-    }
-
-    if (cchBuffer < 1 + cchTotal)
-    {
-        if (NULL != buffer &&
-            cchBuffer > 0)
-        {
-            buffer[0] = '\0';
-        }
-
-        return 1 + cchTotal;
-    }
-
-    STLSOFT_API_EXTERNAL_memfns_memcpy(&buffer[0] + 0, drive, sizeof(ws_char_a_t) * cchDrive);
-    STLSOFT_API_EXTERNAL_memfns_memcpy(&buffer[0] + cchDrive, directory, sizeof(ws_char_a_t) * cchDirectory);
-    buffer[cchDrive + cchDirectory] = '\0';
-
-    return cchTotal;
+    return WINSTL_API_INTERNAL_System_get_home_directory_a_(buffer, STLSOFT_STATIC_CAST(DWORD, cchBuffer));
 }
 
 STLSOFT_INLINE
@@ -147,35 +123,7 @@ winstl_C_get_home_directory_w(
 ,   ws_size_t   cchBuffer
 )
 {
-    /* NOTE: assumes that HOMEDRIVE and HOMEPATH can never be larger than _MAX_PATH */
-
-    ws_char_w_t     drive[WINSTL_CONST_MAX_PATH];
-    ws_char_w_t     directory[WINSTL_CONST_MAX_PATH];
-    DWORD const     cchDrive        =   WINSTL_API_EXTERNAL_SystemInformation_GetEnvironmentVariableW(L"HOMEDRIVE", &drive[0], STLSOFT_NUM_ELEMENTS(drive));
-    DWORD const     cchDirectory    =   (0 == cchDrive) ? 0 : WINSTL_API_EXTERNAL_SystemInformation_GetEnvironmentVariableW(L"HOMEPATH", &directory[0], STLSOFT_NUM_ELEMENTS(directory));
-    DWORD const     cchTotal        =   cchDrive + cchDirectory;
-
-    if (0 == cchDirectory)
-    {
-        return 0;
-    }
-
-    if (cchBuffer < 1 + cchTotal)
-    {
-        if (NULL != buffer &&
-            cchBuffer > 0)
-        {
-            buffer[0] = '\0';
-        }
-
-        return 1 + cchTotal;
-    }
-
-    STLSOFT_API_EXTERNAL_memfns_memcpy(&buffer[0] + 0, drive, sizeof(ws_char_w_t) * cchDrive);
-    STLSOFT_API_EXTERNAL_memfns_memcpy(&buffer[0] + cchDrive, directory, sizeof(ws_char_w_t) * cchDirectory);
-    buffer[cchDrive + cchDirectory] = '\0';
-
-    return cchTotal;
+    return WINSTL_API_INTERNAL_System_get_home_directory_w_(buffer, STLSOFT_STATIC_CAST(DWORD, cchBuffer));
 }
 
 
@@ -204,9 +152,34 @@ get_home_directory(
 {
     return winstl_C_get_home_directory_w(buffer, cchBuffer);
 }
+# ifdef STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT
+
+template <ss_size_t N>
+inline
+ws_size_t
+get_home_directory(
+    ws_char_a_t   (&ar)[N]
+)
+{
+    return get_home_directory(&ar[0], N);
+}
+
+template <ss_size_t N>
+inline
+ws_size_t
+get_home_directory(
+    ws_char_w_t   (&ar)[N]
+)
+{
+    return get_home_directory(&ar[0], N);
+}
+# endif /* STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT */
 #endif /* __cplusplus */
 
-/* ////////////////////////////////////////////////////////////////////// */
+
+/* /////////////////////////////////////////////////////////////////////////
+ * main()
+ */
 
 #ifndef WINSTL_NO_NAMESPACE
 # if defined(STLSOFT_NO_NAMESPACE) || \

--- a/test/component/winstl/CMakeLists.txt
+++ b/test/component/winstl/CMakeLists.txt
@@ -2,3 +2,4 @@
 add_subdirectory(dl)
 add_subdirectory(registry)
 add_subdirectory(synch)
+add_subdirectory(system)

--- a/test/component/winstl/system/CMakeLists.txt
+++ b/test/component/winstl/system/CMakeLists.txt
@@ -1,0 +1,2 @@
+# SIS:AUTO_GENERATED: Remove this line if you edit the file, otherwise it will be overwritten
+add_subdirectory(test.component.system.directory_functions)

--- a/test/component/winstl/system/test.component.system.directory_functions/CMakeLists.txt
+++ b/test/component/winstl/system/test.component.system.directory_functions/CMakeLists.txt
@@ -1,0 +1,2 @@
+# SIS:AUTO_GENERATED: Remove this line if you edit the file, otherwise it will be overwritten
+define_automated_test_program(test.component.winstl.system.directory_functions entry.cpp)

--- a/test/component/winstl/system/test.component.system.directory_functions/entry.cpp
+++ b/test/component/winstl/system/test.component.system.directory_functions/entry.cpp
@@ -1,0 +1,316 @@
+/* /////////////////////////////////////////////////////////////////////////
+ * File:    test.component.winstl.system.directory_functions/entry.c
+ *
+ * Purpose: Component test for WinSTL atomic_functions.
+ *
+ * Created: sometime in 2015
+ * Updated: 20th March 2025
+ *
+ * ////////////////////////////////////////////////////////////////////// */
+
+
+/* /////////////////////////////////////////////////////////////////////////
+ * includes
+ */
+
+/* ///////////////////////////////////////////////
+ * test component header file include(s)
+ */
+
+#include <winstl/system/directory_functions.h>
+
+/* ///////////////////////////////////////////////
+ * general includes
+ */
+
+/* xTests header files */
+#include <xtests/terse-api.h>
+
+/* STLSoft header files */
+#include <platformstl/system/environment_variable_scope.hpp>
+
+/* Standard C++ header files */
+// #include <thread>
+// #include <vector>
+
+/* Standard C header files */
+#include <stdlib.h>
+
+
+/* /////////////////////////////////////////////////////////////////////////
+ * forward declarations
+ */
+
+namespace {
+
+    void TEST_get_home_directory_EXCESS_SPACE();
+    void TEST_get_home_directory_SUFFICIENT_SPACE();
+    void TEST_get_home_directory_INSUFFICIENT_SPACE();
+} // anonymous namespace
+
+
+/* /////////////////////////////////////////////////////////////////////////
+ * main()
+ */
+
+int main(int argc, char* argv[])
+{
+    int retCode = EXIT_SUCCESS;
+    int verbosity = 2;
+
+    XTESTS_COMMANDLINE_PARSEVERBOSITY(argc, argv, &verbosity);
+
+    if (XTESTS_START_RUNNER("test.component.winstl.system.directory_functions", verbosity))
+    {
+        XTESTS_RUN_CASE(TEST_get_home_directory_EXCESS_SPACE);
+        XTESTS_RUN_CASE(TEST_get_home_directory_SUFFICIENT_SPACE);
+        XTESTS_RUN_CASE(TEST_get_home_directory_INSUFFICIENT_SPACE);
+
+        XTESTS_PRINT_RESULTS();
+
+        XTESTS_END_RUNNER_UPDATE_EXITCODE(&retCode);
+    }
+
+    return retCode;
+}
+
+
+/* /////////////////////////////////////////////////////////////////////////
+ * test function implementations
+ */
+
+namespace {
+
+void TEST_get_home_directory_EXCESS_SPACE()
+{
+    platformstl::environment_variable_scope scoper_HOMEDRIVE("HOMEDRIVE", "X:");
+    platformstl::environment_variable_scope scoper_HOMEPATH("HOMEPATH", "\\Users\\me");
+    platformstl::environment_variable_scope scoper_USERPROFILE("USERPROFILE", "X:\\Users\\me");
+
+    {
+        char            buff[1001];
+        size_t const    cch =   winstl::get_home_directory(buff, STLSOFT_NUM_ELEMENTS(buff));
+
+        TEST_INT_EQ(11, cch);
+        TEST_MS_EQ("X:\\Users\\me", buff);
+    }
+#ifdef STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT
+
+    {
+        char            buff[1001];
+        size_t const    cch =   winstl::get_home_directory(buff);
+
+        TEST_INT_EQ(11, cch);
+        TEST_MS_EQ("X:\\Users\\me", buff);
+    }
+#endif /* STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT */
+}
+
+void TEST_get_home_directory_SUFFICIENT_SPACE()
+{
+    platformstl::environment_variable_scope scoper_HOMEDRIVE("HOMEDRIVE", "X:");
+    platformstl::environment_variable_scope scoper_HOMEPATH("HOMEPATH", "\\Users\\me");
+    platformstl::environment_variable_scope scoper_USERPROFILE("USERPROFILE", "Y:\\Users\\me");
+
+    {
+        {
+            char            buff[12];
+            size_t const    cch =   winstl::get_home_directory(buff, STLSOFT_NUM_ELEMENTS(buff));
+
+            TEST_INT_EQ(11, cch);
+            TEST_MS_EQ("Y:\\Users\\me", buff);
+        }
+
+        {
+            wchar_t         buff[12];
+            size_t const    cch =   winstl::get_home_directory(buff, STLSOFT_NUM_ELEMENTS(buff));
+
+            TEST_INT_EQ(11, cch);
+            TEST_WS_EQ(L"Y:\\Users\\me", buff);
+        }
+#ifdef STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT
+
+        {
+            char            buff[12];
+            size_t const    cch =   winstl::get_home_directory(buff);
+
+            TEST_INT_EQ(11, cch);
+            TEST_MS_EQ("Y:\\Users\\me", buff);
+        }
+
+        {
+            wchar_t         buff[12];
+            size_t const    cch =   winstl::get_home_directory(buff);
+
+            TEST_INT_EQ(11, cch);
+            TEST_WS_EQ(L"Y:\\Users\\me", buff);
+        }
+#endif /* STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT */
+    }
+
+    {
+        {
+            platformstl::environment_variable_scope scoper_HOMEDRIVE_1("HOMEDRIVE", NULL);
+            platformstl::environment_variable_scope scoper_HOMEPATH_1("HOMEPATH", NULL);
+
+            {
+                char            buff[12];
+                size_t const    cch =   winstl::get_home_directory(buff, STLSOFT_NUM_ELEMENTS(buff));
+
+                TEST_INT_EQ(11, cch);
+                TEST_MS_EQ("Y:\\Users\\me", buff);
+            }
+        }
+#ifdef STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT
+
+        {
+            platformstl::environment_variable_scope scoper_HOMEDRIVE_1("HOMEDRIVE", NULL);
+            platformstl::environment_variable_scope scoper_HOMEPATH_1("HOMEPATH", NULL);
+
+            {
+                char            buff[12];
+                size_t const    cch =   winstl::get_home_directory(buff);
+
+                TEST_INT_EQ(11, cch);
+                TEST_MS_EQ("Y:\\Users\\me", buff);
+            }
+        }
+#endif /* STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT */
+    }
+
+    {
+        {
+            platformstl::environment_variable_scope scoper_HOMEDRIVE_2("HOMEDRIVE", NULL);
+
+            {
+                char            buff[12];
+                size_t const    cch =   winstl::get_home_directory(buff, STLSOFT_NUM_ELEMENTS(buff));
+
+                TEST_INT_EQ(11, cch);
+                TEST_MS_EQ("Y:\\Users\\me", buff);
+            }
+        }
+#ifdef STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT
+
+        {
+            platformstl::environment_variable_scope scoper_HOMEDRIVE_2("HOMEDRIVE", NULL);
+
+            {
+                char            buff[12];
+                size_t const    cch =   winstl::get_home_directory(buff);
+
+                TEST_INT_EQ(11, cch);
+                TEST_MS_EQ("Y:\\Users\\me", buff);
+            }
+        }
+#endif /* STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT */
+    }
+
+    {
+        {
+            platformstl::environment_variable_scope scoper_HOMEPATH_3("HOMEPATH", NULL);
+
+            {
+                char            buff[12];
+                size_t const    cch =   winstl::get_home_directory(buff, STLSOFT_NUM_ELEMENTS(buff));
+
+                TEST_INT_EQ(11, cch);
+                TEST_MS_EQ("Y:\\Users\\me", buff);
+            }
+        }
+#ifdef STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT
+
+        {
+            platformstl::environment_variable_scope scoper_HOMEPATH_3("HOMEPATH", NULL);
+
+            {
+                char            buff[12];
+                size_t const    cch =   winstl::get_home_directory(buff);
+
+                TEST_INT_EQ(11, cch);
+                TEST_MS_EQ("Y:\\Users\\me", buff);
+            }
+        }
+#endif /* STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT */
+    }
+
+    {
+        {
+            platformstl::environment_variable_scope scoper_USERPROFILE_4("USERPROFILE", NULL);
+
+            {
+                char            buff[12];
+                size_t const    cch =   winstl::get_home_directory(buff, STLSOFT_NUM_ELEMENTS(buff));
+
+                TEST_INT_EQ(11, cch);
+                TEST_MS_EQ("X:\\Users\\me", buff);
+            }
+        }
+#ifdef STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT
+
+        {
+            platformstl::environment_variable_scope scoper_USERPROFILE_4("USERPROFILE", NULL);
+
+            {
+                char            buff[12];
+                size_t const    cch =   winstl::get_home_directory(buff);
+
+                TEST_INT_EQ(11, cch);
+                TEST_MS_EQ("X:\\Users\\me", buff);
+            }
+        }
+#endif /* STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT */
+    }
+}
+
+void TEST_get_home_directory_INSUFFICIENT_SPACE()
+{
+    platformstl::environment_variable_scope scoper_HOMEDRIVE("HOMEDRIVE", "X:");
+    platformstl::environment_variable_scope scoper_HOMEPATH("HOMEPATH", "\\Users\\me");
+    platformstl::environment_variable_scope scoper_USERPROFILE("USERPROFILE", "X:\\Users\\me");
+
+    {
+        {
+            char            buff[1] = { '~' };
+            size_t const    cch =   winstl::get_home_directory(buff, STLSOFT_NUM_ELEMENTS(buff));
+
+            TEST_INT_EQ(12, cch);
+            TEST_CHAR_EQ('~', buff[0]);
+        }
+#ifdef STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT
+
+        {
+            char            buff[1] = { '~' };
+            size_t const    cch =   winstl::get_home_directory(buff);
+
+            TEST_INT_EQ(12, cch);
+            TEST_CHAR_EQ('~', buff[0]);
+        }
+#endif /* STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT */
+    }
+
+    {
+        {
+            char            buff[10] = { '~' };
+            size_t const    cch =   winstl::get_home_directory(buff, STLSOFT_NUM_ELEMENTS(buff));
+
+            TEST_INT_EQ(12, cch);
+            TEST_CHAR_EQ('~', buff[0]);
+        }
+#ifdef STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT
+
+        {
+            char            buff[10] = { '~' };
+            size_t const    cch =   winstl::get_home_directory(buff);
+
+            TEST_INT_EQ(12, cch);
+            TEST_CHAR_EQ('~', buff[0]);
+        }
+#endif /* STLSOFT_CF_STATIC_ARRAY_SIZE_DETERMINATION_SUPPORT */
+    }
+}
+} // anonymous namespace
+
+
+/* ///////////////////////////// end of file //////////////////////////// */
+


### PR DESCRIPTION
 * add `WINSTL_API_INTERNAL_System_get_home_directory_a_()` / `WINSTL_API_INTERNAL_System_get_home_directory_w_()`;
 * tries first for `"USERPROFILE"` and then falls back to `"HOMEDRIVE"` and `"HOMEPATH"`;
 * implement `winstl_C_get_home_directory_a()` / `winstl_C_get_home_directory_w()` (**winstl/system/directory_functions.h**) in terms of `WINSTL_API_INTERNAL_System_get_home_directory_a_()` / `WINSTL_API_INTERNAL_System_get_home_directory_w_()`;
 * add **test.component.winstl.system.directory_functions**;